### PR TITLE
Smart timer

### DIFF
--- a/BoosterCreator/BoosterHandler.cs
+++ b/BoosterCreator/BoosterHandler.cs
@@ -3,6 +3,7 @@ using ArchiSteamFarm.Localization;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -16,20 +17,22 @@ using JetBrains.Annotations;
 namespace BoosterCreator {
 	internal sealed class BoosterHandler : IDisposable {
 		private readonly Bot Bot;
-		private readonly IReadOnlyCollection<uint> GameIDs;
+		private readonly ConcurrentDictionary<uint,DateTime?> GameIDs = new ConcurrentDictionary<uint, DateTime?>();
 		private readonly Timer BoosterTimer;
 
 		internal static ConcurrentDictionary<string, BoosterHandler> BoosterHandlers = new ConcurrentDictionary<string, BoosterHandler>();
 
 		internal BoosterHandler([NotNull] Bot bot, IReadOnlyCollection<uint> gameIDs) {
 			Bot = bot ?? throw new ArgumentNullException(nameof(bot));
-			GameIDs = gameIDs;
+			foreach(var gameID in gameIDs) {
+				GameIDs.TryAdd(gameID, DateTime.Now.AddHours(1));
+			}
 
 			BoosterTimer = new Timer(
 				async e => await AutoBooster().ConfigureAwait(false),
 				null,
-				TimeSpan.FromHours(1.1) + TimeSpan.FromSeconds(Bot.BotsReadOnly.Count * ASF.GlobalConfig.LoginLimiterDelay * 3),
-				TimeSpan.FromHours(8.1)
+				TimeSpan.FromHours(1) + TimeSpan.FromSeconds(Bot.BotsReadOnly.Count * ASF.GlobalConfig.LoginLimiterDelay * 3),
+				TimeSpan.FromHours(1)
 			);
 		}
 
@@ -40,10 +43,11 @@ namespace BoosterCreator {
 				return;
 			}
 
-			await CreateBooster(Bot, GameIDs).ConfigureAwait(false);
+			string response = await CreateBooster(Bot, GameIDs).ConfigureAwait(false);
+			ASF.ArchiLogger.LogGenericInfo (response);
 		}
 
-		internal static async Task<string> CreateBooster(Bot bot, IReadOnlyCollection<uint> gameIDs) {
+		internal static async Task<string> CreateBooster(Bot bot, ConcurrentDictionary<uint, DateTime?> gameIDs) {
 			if (!gameIDs.Any()) {
 				bot.ArchiLogger.LogNullError(nameof(gameIDs));
 
@@ -73,26 +77,42 @@ namespace BoosterCreator {
 
 			StringBuilder response = new StringBuilder();
 
-			foreach (uint gameID in gameIDs) {
+			foreach (var gameID in gameIDs) {
 				await Task.Delay(500).ConfigureAwait(false);
 
-				if (!boosterInfos.ContainsKey(gameID)) {
+				if (!boosterInfos.ContainsKey(gameID.Key)) {
 					response.AppendLine(Commands.FormatBotResponse(bot, string.Format(Strings.BotAddLicense, gameID, "NotEligible")));
-
+					//If we are not eligible - wait 8 hours, just in case game will be added to account later
+					if (gameID.Value.HasValue) { //if source is timer, not command
+						gameIDs[gameID.Key] = DateTime.Now.AddHours(8);
+					}
 					continue;
 				}
 
-				Steam.BoosterInfo bi = boosterInfos[gameID];
+				Steam.BoosterInfo bi = boosterInfos[gameID.Key];
 
 				if (gooAmount < bi.Price) {
 					response.AppendLine(Commands.FormatBotResponse(bot, string.Format(Strings.BotAddLicense, gameID, "NotEnoughGems")));
-
+					//If we have not enough gems - wait 8 hours, just in case gems will be added to account later
+					if (gameID.Value.HasValue) { //if source is timer, not command
+						gameIDs[gameID.Key] = DateTime.Now.AddHours(8);
+					}
 					continue;
 				}
 
 				if (bi.Unavailable) {
 					response.AppendLine(Commands.FormatBotResponse(bot, string.Format(Strings.BotAddLicense, gameID, $"Available at time: {bi.AvailableAtTime}")));
+					//Wait until specified time
+					DateTime availableAtTime;
 
+					if (DateTime.TryParseExact(bi.AvailableAtTime, "d MMM @ h:mmtt", CultureInfo.CurrentCulture, DateTimeStyles.None, out availableAtTime)) {
+						DateTime convertedTime = TimeZoneInfo.ConvertTime(availableAtTime, ValveTimeZone.GetTimeZoneInfo(), TimeZoneInfo.Local);
+						if (gameID.Value.HasValue) { //if source is timer, not command
+							gameIDs[gameID.Key] = convertedTime;
+						}
+					} else {
+						ASF.ArchiLogger.LogGenericInfo("Unable to parse time \""+ bi.AvailableAtTime+"\", please report this.");
+					}
 					continue;
 				}
 
@@ -108,7 +128,10 @@ namespace BoosterCreator {
 
 				if (result?.Result?.Result != EResult.OK) {
 					response.AppendLine(Commands.FormatBotResponse(bot, string.Format(Strings.BotAddLicense, bi.AppID, EResult.Fail)));
-
+					//Some unhandled error - wait 8 hours before retry
+					if (gameID.Value.HasValue) { //if source is timer, not command
+						gameIDs[gameID.Key] = DateTime.Now.AddHours(8);
+					}
 					continue;
 				}
 				
@@ -116,6 +139,20 @@ namespace BoosterCreator {
 				tradableGooAmount = result.TradableGooAmount;
 				unTradableGooAmount = result.UntradableGooAmount;
 				response.AppendLine(Commands.FormatBotResponse(bot, string.Format(Strings.BotAddLicenseWithItems, bi.AppID, EResult.OK, bi.Name)));
+				//Buster was made - next is only available in 24 hours
+				if (gameID.Value.HasValue) { //if source is timer, not command
+					gameIDs[gameID.Key] = DateTime.Now.AddHours(24);
+				}
+
+
+			}
+
+			//Get nearest time when we should try for new booster;
+			DateTime? nextTry = gameIDs.Values.Min<DateTime?>();
+
+			if (nextTry.HasValue) { //if it was not from command
+				//Add 10 minutes to avoid race conditions
+				BoosterHandler.BoosterHandlers[bot.BotName].BoosterTimer.Change(nextTry.Value - DateTime.Now + TimeSpan.FromMinutes(10), nextTry.Value - DateTime.Now + TimeSpan.FromMinutes(10));
 			}
 
 			return response.Length > 0 ? response.ToString() : null;

--- a/BoosterCreator/Commands.cs
+++ b/BoosterCreator/Commands.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections.Concurrent;
 using ArchiSteamFarm;
 using ArchiSteamFarm.Localization;
 
@@ -39,19 +40,21 @@ namespace BoosterCreator {
 				return FormatBotResponse(bot, string.Format(Strings.ErrorIsEmpty, nameof(gameIDs)));
 			}
 
-			HashSet<uint> gamesToBooster = new HashSet<uint>();
+
+			ConcurrentDictionary<uint, DateTime?> gamesToBooster = new ConcurrentDictionary<uint, DateTime?>();
+			//HashSet<uint> gamesToBooster = new HashSet<uint>();
 
 			foreach (string game in gameIDs) {
 				if (!uint.TryParse(game, out uint gameID) || (gameID == 0)) {
 					return FormatBotResponse(bot, string.Format(Strings.ErrorParsingObject, nameof(gameID)));
 				}
 
-				gamesToBooster.Add(gameID);
+				gamesToBooster.TryAdd(gameID, null);
 			}
 
 			return await BoosterHandler.CreateBooster(bot, gamesToBooster).ConfigureAwait(false);
 		}
-		
+
 		private static async Task<string> ResponseBooster(ulong steamID, string botNames, string targetGameIDs) {
 			if ((steamID == 0) || string.IsNullOrEmpty(botNames) || string.IsNullOrEmpty(targetGameIDs)) {
 				ASF.ArchiLogger.LogNullError(nameof(steamID) + " || " + nameof(botNames) + " || " + nameof(targetGameIDs));

--- a/BoosterCreator/ValveTimeZone.cs
+++ b/BoosterCreator/ValveTimeZone.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace BoosterCreator {
+	static class ValveTimeZone {
+		static public TimeZoneInfo GetTimeZoneInfo() {
+			TimeZoneInfo.TransitionTime startTransition, endTransition;
+			startTransition = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0),
+																				  4, 1, DayOfWeek.Sunday);
+			endTransition = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0),
+																			10, 5, DayOfWeek.Sunday);
+			// Define adjustment rule
+			TimeSpan delta = new TimeSpan(1, 0, 0);
+			TimeZoneInfo.AdjustmentRule adjustment = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(new DateTime(1999, 10, 1), DateTime.MaxValue.Date, delta, startTransition, endTransition);
+			// Create array for adjustment rules
+			TimeZoneInfo.AdjustmentRule[] adjustments = { adjustment };
+			// Define other custom time zone arguments
+			string displayName = "(GMT-08:00) Valve Time";
+			string standardName = "Valve Standard Time";
+			string daylightName = "Valve Daylight Time";
+			TimeSpan offset = new TimeSpan(-8, 0, 0);
+			// Create custom time zone without copying DST information
+			TimeZoneInfo valveTime = TimeZoneInfo.CreateCustomTimeZone(standardName, offset, displayName, standardName, daylightName, adjustments, true);
+			return valveTime;
+		}
+	}
+}


### PR DESCRIPTION
Hello!
I found your plugin quite useful, and I'd like to suggest some improvements to it.
Right now you are checking all busters in the list at regular time intervals. I believe this is excessive, because if booster creation is unavailable at this moment - we can get exact time, when it will be available, and if booster was successfully created - we know that next time it will be available in 24 hours. So, I tried to implement those smart timer changes based on known time, when booster will be available.
I tried my best to comment the code, but if you need further explanations I will gladly provide it. Also, I only tested this with one booster in the list - don't have enough gems for tests.
As a side improvement - I added logging of events of automatic booster creator. 
Thank you for your plugin and for considering this PR.